### PR TITLE
fix Chart.js

### DIFF
--- a/app/views/admin/bikes/show.html.erb
+++ b/app/views/admin/bikes/show.html.erb
@@ -167,12 +167,13 @@
 <%= render "layouts/footer" %>
 
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
   <script>
     $(document).on('turbolinks:load', function(){
+      // 要素が見つからない場合、ここでガードする
+      var element = document.getElementById("myChart");
+      if(!element) { return }
 
-
-      var ctx = document.getElementById("myChart").getContext('2d');
+      var ctx = element.getContext('2d');
       var myChart = new Chart(ctx, {
           type: 'radar',
           data: {

--- a/app/views/bikes/show.html.erb
+++ b/app/views/bikes/show.html.erb
@@ -262,12 +262,13 @@
   </script>
 
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
   <script type="text/javascript">
     $(document).on('turbolinks:load', function(){
+      // 要素が見つからない場合、ここでガードする
+      var element = document.getElementById("myChart");
+      if(!element) { return }
 
-
-      var ctx = document.getElementById("myChart").getContext('2d');
+      var ctx = element.getContext('2d');
       var myChart = new Chart(ctx, {
           type: 'radar',
           data: {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   </head>
 
   <body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
# 前提知識
turbolinksは、titleとbodyタグの中身を切り替えることで、headタグ部分や各assetを再ロードせずに高速化を実現しています。
そのため、bodyタグにJSを書いてしまっていると、たとえ
```
$(document).on 'turbolinks:load',
```
と記述していても、JavaScript自体はページ遷移のたびにロードされてしまうようです。

`application.js` については通常headタグでロードさせているため、何度もロードされることはありません。

![image](https://kray.jp/wp/wp-content/uploads/2013/03/turbolinks-668x325.png)

https://kray.jp/blog/must-know-about-turbolinks/ より引用

# 問題点
## Chart.js が必要な時にロードされていない
* CDN(Chart.js)のロードを `/bikes/show.html.erb` に記載している
* CDNの部分は一度しかロードされないっぽく(ここちょっと挙動謎です)、ページ遷移で Chart.js を使うところに来た際にエラーとなっていた
* 例えば、`検索 → バイク選択` でエラー再現可能

<img width="1440" alt="スクリーンショット 2019-10-27 17 15 45" src="https://user-images.githubusercontent.com/14919586/67631737-8a1b0c00-f8dd-11e9-896b-de0474506db2.png">


##  myChart がないページでも該当JSが発火している
* JavaScriptを個別のページに記載している箇所がある
* 問題となっているのは `/bikes/show.html.erb` で、ここに書かれているJavaScriptが他ページに遷移する毎に発火し、その際、以下で `myChart` が見つからずに `getContext` でエラーが起きていた
```
      var ctx = document.getElementById("myChart").getContext('2d');
```


# 根本的な解決方法

1. turbolinks をやめる
2. application.js 以外にJavaScriptを書かない (bodyタグにJSを書かない) [参考](https://qiita.com/saboyutaka/items/bcc0966313c6f7399a6e#%E3%81%A7%E3%81%8D%E3%82%8B%E3%81%A0%E3%81%91applicationjs-applicationcss%E3%81%AB%E3%81%BE%E3%81%A8%E3%82%81%E3%82%8B)

2が健全ですが、JavaScriptの中で `<%= @reviews %>` とRails側から渡されるインスタンス変数を動的に参照している箇所があるので、ささっとは直せないと判断しました。
今回はエラーを起こさないようにピンポイントで修正しています。